### PR TITLE
feat: added color blind feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "https://github.com/Douglas-Strey/douglastrey.com.br-2.0/issues"
   },
   "homepage": "https://github.com/Douglas-Strey/douglastrey.com.br-2.0#readme",
+  "engines": {
+    "node": "24.x"
+  },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -321,7 +321,7 @@ export default function App() {
             Douglas<span className="text-primary">.</span>
           </a>
 
-          <nav className="hidden items-center gap-6 text-sm text-muted-foreground md:flex">
+          <nav className="hidden items-center gap-6 text-sm text-muted-foreground xl:flex">
             {navigation.map((item) => (
               <a key={item.href} href={item.href} className="transition-colors hover:text-foreground">
                 {item.label}
@@ -330,7 +330,7 @@ export default function App() {
           </nav>
 
           <div className="flex items-center gap-3">
-            <div className="hidden items-center gap-3 md:flex">
+            <div className="hidden items-center gap-3 xl:flex">
               <VisionToggle value={visionMode} onChange={setVisionMode} labels={visionLabels} />
               <LanguageToggle value={language} onChange={setLanguage} />
               <ThemeToggle value={theme} onChange={setTheme} />
@@ -339,7 +339,7 @@ export default function App() {
               type="button"
               variant="outline"
               size="icon"
-              className="md:hidden"
+              className="xl:hidden"
               onClick={openMobileMenu}
               aria-label="Abrir menu"
             >
@@ -352,7 +352,7 @@ export default function App() {
       {mobileMenuOpen ? (
         <div
           className={cn(
-            "fixed inset-0 z-[90] transition-all duration-200 md:hidden",
+            "fixed inset-0 z-[90] transition-all duration-200 xl:hidden",
             isMobileMenuVisible
               ? "bg-background/86 opacity-100 backdrop-blur-xl"
               : "bg-background/0 opacity-0 backdrop-blur-none",
@@ -361,7 +361,7 @@ export default function App() {
         >
           <div
             className={cn(
-              "ml-auto flex h-full w-[min(90vw,23rem)] flex-col border-l border-white/10 bg-[linear-gradient(180deg,hsl(var(--card))/0.98,transparent),linear-gradient(155deg,hsl(var(--primary))/0.1,transparent_52%),linear-gradient(180deg,hsl(var(--accent))/0.12,transparent_68%)] px-6 py-6 shadow-2xl transition-all duration-300 ease-out",
+              "ml-auto flex h-full w-[min(90vw,23rem)] flex-col overflow-y-auto border-l border-white/10 bg-[linear-gradient(180deg,hsl(var(--card))/0.98,transparent),linear-gradient(155deg,hsl(var(--primary))/0.1,transparent_52%),linear-gradient(180deg,hsl(var(--accent))/0.12,transparent_68%)] px-6 py-6 shadow-2xl transition-all duration-300 ease-out",
               isMobileMenuVisible
                 ? "translate-x-0 opacity-100"
                 : "translate-x-8 opacity-0",
@@ -401,35 +401,39 @@ export default function App() {
               ))}
             </nav>
 
-            <div className="mt-6 grid gap-4 rounded-[1.6rem] border border-white/10 bg-background/72 p-4">
-              <div className="space-y-2">
+            <div className="mt-7 rounded-[1.6rem] border border-white/10 bg-background/72 p-5">
+              <div className="grid gap-5">
+                <div className="space-y-2.5">
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   {visionLabels.title}
                 </p>
                 <VisionToggle value={visionMode} onChange={setVisionMode} labels={visionLabels} />
               </div>
-              <div className="space-y-2">
-                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                  Idioma
-                </p>
-                <LanguageToggle value={language} onChange={setLanguage} />
-              </div>
-              <div className="space-y-2">
-                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
-                  Tema
-                </p>
-                <ThemeToggle value={theme} onChange={setTheme} />
+                <div className="grid gap-4">
+                  <div className="space-y-2.5">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                      Idioma
+                    </p>
+                    <LanguageToggle value={language} onChange={setLanguage} />
+                  </div>
+                  <div className="space-y-2.5">
+                    <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                      Tema
+                    </p>
+                    <ThemeToggle value={theme} onChange={setTheme} />
+                  </div>
+                </div>
               </div>
             </div>
 
-            <div className="mt-auto space-y-3 pt-6">
+            <div className="mt-6 border-t border-white/10 pt-8">
               <Button asChild size="lg" className="w-full" onClick={closeMobileMenu}>
                 <a href="#contact">
                   {copy.hero.primaryCta}
                   <ArrowRight className="size-4" />
                 </a>
               </Button>
-              <Button asChild size="lg" variant="outline" className="w-full" onClick={closeMobileMenu}>
+              <Button asChild size="lg" variant="outline" className="mt-3 w-full" onClick={closeMobileMenu}>
                 <a
                   href="https://www.linkedin.com/in/douglas-strey/"
                   target="_blank"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,13 @@ import { useEffect, useMemo, useRef, useState, type TouchEvent } from "react";
 import {
   ArrowRight,
   BriefcaseBusiness,
+  CheckCircle2,
   ChevronLeft,
   ChevronRight,
   GraduationCap,
   ExternalLink,
+  FolderLock,
+  Globe2,
   Github,
   Instagram,
   Linkedin,
@@ -22,6 +25,7 @@ import {
 import { LanguageToggle } from "@/components/language-toggle";
 import { SectionHeading } from "@/components/section-heading";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { VisionToggle } from "@/components/vision-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,9 +35,16 @@ import { siteContent, type Language } from "@/data/site-content";
 import { cn } from "@/lib/utils";
 
 type Theme = "system" | "light" | "dark";
+type VisionMode =
+  | "default"
+  | "deuteranopia"
+  | "protanopia"
+  | "tritanopia"
+  | "monochromacy";
 
 const languageStorageKey = "douglas-site-language";
 const themeStorageKey = "douglas-site-theme";
+const visionStorageKey = "douglas-site-vision";
 
 function getPreferredLanguage(): Language {
   if (typeof window === "undefined") {
@@ -61,9 +72,24 @@ function resolveSystemTheme() {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
+function getPreferredVisionMode(): VisionMode {
+  if (typeof window === "undefined") {
+    return "default";
+  }
+
+  const saved = window.localStorage.getItem(visionStorageKey);
+  return saved === "deuteranopia" ||
+    saved === "protanopia" ||
+    saved === "tritanopia" ||
+    saved === "monochromacy"
+    ? saved
+    : "default";
+}
+
 export default function App() {
   const [language, setLanguage] = useState<Language>(() => getPreferredLanguage());
   const [theme, setTheme] = useState<Theme>(() => getPreferredTheme());
+  const [visionMode, setVisionMode] = useState<VisionMode>(() => getPreferredVisionMode());
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isMobileMenuVisible, setIsMobileMenuVisible] = useState(false);
   const [expandedProject, setExpandedProject] = useState<null | { title: string; images: string[]; index: number }>(null);
@@ -94,6 +120,20 @@ export default function App() {
 
     return () => media.removeEventListener("change", syncTheme);
   }, [theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove(
+      "vision-deuteranopia",
+      "vision-protanopia",
+      "vision-tritanopia",
+      "vision-monochromacy",
+    );
+    if (visionMode !== "default") {
+      root.classList.add(`vision-${visionMode}`);
+    }
+    window.localStorage.setItem(visionStorageKey, visionMode);
+  }, [visionMode]);
 
   useEffect(() => {
     if (!mobileMenuOpen && !expandedProject) {
@@ -264,6 +304,8 @@ export default function App() {
     [copy.nav],
   );
 
+  const visionLabels = copy.accessibility;
+
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-background text-foreground">
       <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
@@ -289,6 +331,7 @@ export default function App() {
 
           <div className="flex items-center gap-3">
             <div className="hidden items-center gap-3 md:flex">
+              <VisionToggle value={visionMode} onChange={setVisionMode} labels={visionLabels} />
               <LanguageToggle value={language} onChange={setLanguage} />
               <ThemeToggle value={theme} onChange={setTheme} />
             </div>
@@ -359,6 +402,12 @@ export default function App() {
             </nav>
 
             <div className="mt-6 grid gap-4 rounded-[1.6rem] border border-white/10 bg-background/72 p-4">
+              <div className="space-y-2">
+                <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                  {visionLabels.title}
+                </p>
+                <VisionToggle value={visionMode} onChange={setVisionMode} labels={visionLabels} />
+              </div>
               <div className="space-y-2">
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
                   Idioma
@@ -569,7 +618,15 @@ export default function App() {
                 <CardContent className="p-5 sm:p-7">
                   <div className="flex items-start justify-between gap-4">
                     <div className="space-y-3">
-                      <Badge variant={isCurrent ? "default" : "secondary"}>{item.period}</Badge>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={isCurrent ? "default" : "secondary"}>{item.period}</Badge>
+                        {isCurrent ? (
+                          <Badge variant="outline" className="gap-1.5">
+                            <CheckCircle2 className="size-3.5" />
+                            {copy.accessibility.currentLabel}
+                          </Badge>
+                        ) : null}
+                      </div>
                       <div className="space-y-1">
                         <h3 className="font-display text-xl tracking-tight text-foreground sm:text-2xl">
                           {item.title}
@@ -679,7 +736,13 @@ export default function App() {
                   />
                 </button>
                 <CardHeader className="p-5 pb-2 sm:p-6 sm:pb-2">
-                  <CardDescription>{project.status}</CardDescription>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline" className="gap-1.5">
+                      {project.href ? <Globe2 className="size-3.5" /> : <FolderLock className="size-3.5" />}
+                      {project.href ? copy.accessibility.publicProjectLabel : copy.accessibility.privateProjectLabel}
+                    </Badge>
+                    <CardDescription>{project.status}</CardDescription>
+                  </div>
                   <CardTitle>{project.title}</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4 p-5 pt-0 sm:space-y-5 sm:p-6 sm:pt-0">

--- a/src/components/language-toggle.tsx
+++ b/src/components/language-toggle.tsx
@@ -17,8 +17,8 @@ const items: Array<{ label: string; value: Language }> = [
 
 export function LanguageToggle({ value, onChange }: LanguageToggleProps) {
   return (
-    <div className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/70 p-1 backdrop-blur">
-      <span className="px-3 text-muted-foreground">
+    <div className="inline-flex min-h-11 w-full items-center gap-1 rounded-full border border-border/70 bg-background/70 p-1 backdrop-blur">
+      <span className="px-3.5 text-muted-foreground">
         <Languages className="size-4" />
       </span>
       {items.map((item) => (
@@ -28,7 +28,7 @@ export function LanguageToggle({ value, onChange }: LanguageToggleProps) {
           size="sm"
           variant={value === item.value ? "default" : "ghost"}
           className={cn(
-            "rounded-full px-3",
+            "h-9 flex-1 rounded-full px-3.5",
             value !== item.value && "text-muted-foreground",
           )}
           onClick={() => onChange(item.value)}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -18,7 +18,7 @@ const items = [
 
 export function ThemeToggle({ value, onChange }: ThemeToggleProps) {
   return (
-    <div className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background/70 p-1 backdrop-blur">
+    <div className="inline-flex min-h-11 w-full items-center gap-1 rounded-full border border-border/70 bg-background/70 p-1 backdrop-blur">
       {items.map((item) => {
         const Icon = item.icon;
         return (
@@ -28,7 +28,7 @@ export function ThemeToggle({ value, onChange }: ThemeToggleProps) {
             size="sm"
             variant={value === item.value ? "default" : "ghost"}
             className={cn(
-              "rounded-full px-3",
+              "h-9 flex-1 rounded-full px-3.5",
               value !== item.value && "text-muted-foreground",
             )}
             onClick={() => onChange(item.value)}

--- a/src/components/vision-toggle.tsx
+++ b/src/components/vision-toggle.tsx
@@ -1,0 +1,43 @@
+import { Accessibility } from "lucide-react";
+
+type VisionMode =
+  | "default"
+  | "deuteranopia"
+  | "protanopia"
+  | "tritanopia"
+  | "monochromacy";
+
+type VisionToggleProps = {
+  value: VisionMode;
+  onChange: (mode: VisionMode) => void;
+  labels: {
+    title: string;
+    options: ReadonlyArray<{
+      label: string;
+      value: VisionMode;
+    }>;
+  };
+};
+
+export function VisionToggle({ value, onChange, labels }: VisionToggleProps) {
+  return (
+    <label className="inline-flex items-center gap-3 rounded-full border border-border/70 bg-background/70 px-3 py-1.5 backdrop-blur">
+      <span className="text-muted-foreground" aria-hidden="true">
+        <Accessibility className="size-4" />
+      </span>
+      <span className="sr-only">{labels.title}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as VisionMode)}
+        aria-label={labels.title}
+        className="min-w-0 bg-transparent text-sm font-medium text-foreground outline-none"
+      >
+        {labels.options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/components/vision-toggle.tsx
+++ b/src/components/vision-toggle.tsx
@@ -21,7 +21,7 @@ type VisionToggleProps = {
 
 export function VisionToggle({ value, onChange, labels }: VisionToggleProps) {
   return (
-    <label className="inline-flex items-center gap-3 rounded-full border border-border/70 bg-background/70 px-3 py-1.5 backdrop-blur">
+    <label className="inline-flex min-h-11 w-full items-center gap-3 rounded-full border border-border/70 bg-background/70 px-3.5 py-1 backdrop-blur">
       <span className="text-muted-foreground" aria-hidden="true">
         <Accessibility className="size-4" />
       </span>
@@ -30,7 +30,7 @@ export function VisionToggle({ value, onChange, labels }: VisionToggleProps) {
         value={value}
         onChange={(event) => onChange(event.target.value as VisionMode)}
         aria-label={labels.title}
-        className="min-w-0 bg-transparent text-sm font-medium text-foreground outline-none"
+        className="h-9 min-w-0 flex-1 bg-transparent pr-1 text-sm font-medium text-foreground outline-none"
       >
         {labels.options.map((option) => (
           <option key={option.value} value={option.value}>

--- a/src/data/site-content.ts
+++ b/src/data/site-content.ts
@@ -10,6 +10,19 @@ export const siteContent = {
       stack: "Stack",
       contact: "Contato",
     },
+    accessibility: {
+      title: "Acessibilidade de cor",
+      currentLabel: "Atuação atual",
+      publicProjectLabel: "Projeto público",
+      privateProjectLabel: "Projeto interno",
+      options: [
+        { label: "Padrão", value: "default" },
+        { label: "Deuteranopia", value: "deuteranopia" },
+        { label: "Protanopia", value: "protanopia" },
+        { label: "Tritanopia", value: "tritanopia" },
+        { label: "Monocromacia", value: "monochromacy" },
+      ],
+    },
     hero: {
       badge: "Portfólio 2026",
       title: "Lidero times e desenvolvo soluções full-stack para produtos digitais, integrações e operações críticas.",
@@ -337,6 +350,19 @@ export const siteContent = {
       projects: "Projects",
       stack: "Stack",
       contact: "Contact",
+    },
+    accessibility: {
+      title: "Color accessibility",
+      currentLabel: "Current role",
+      publicProjectLabel: "Public project",
+      privateProjectLabel: "Internal project",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Deuteranopia", value: "deuteranopia" },
+        { label: "Protanopia", value: "protanopia" },
+        { label: "Tritanopia", value: "tritanopia" },
+        { label: "Monochromacy", value: "monochromacy" },
+      ],
     },
     hero: {
       badge: "Portfolio 2026",

--- a/src/styles.css
+++ b/src/styles.css
@@ -63,6 +63,118 @@
   --ring: 186 72% 52%;
 }
 
+.vision-deuteranopia {
+  --primary: 221 86% 43%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 41 100% 52%;
+  --accent-foreground: 214 40% 10%;
+  --secondary: 40 38% 90%;
+  --secondary-foreground: 214 38% 16%;
+  --muted: 40 24% 88%;
+  --muted-foreground: 216 18% 28%;
+  --border: 216 20% 72%;
+  --input: 216 20% 72%;
+  --ring: 221 86% 43%;
+}
+
+.dark.vision-deuteranopia {
+  --primary: 210 96% 64%;
+  --primary-foreground: 214 42% 10%;
+  --accent: 45 100% 58%;
+  --accent-foreground: 214 42% 10%;
+  --secondary: 214 24% 22%;
+  --secondary-foreground: 40 20% 94%;
+  --muted: 214 20% 18%;
+  --muted-foreground: 42 14% 78%;
+  --border: 214 20% 30%;
+  --input: 214 20% 30%;
+  --ring: 210 96% 64%;
+}
+
+.vision-protanopia {
+  --primary: 224 82% 44%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 47 100% 50%;
+  --accent-foreground: 214 40% 10%;
+  --secondary: 39 34% 91%;
+  --secondary-foreground: 214 34% 16%;
+  --muted: 38 24% 88%;
+  --muted-foreground: 215 16% 30%;
+  --border: 220 18% 74%;
+  --input: 220 18% 74%;
+  --ring: 224 82% 44%;
+}
+
+.dark.vision-protanopia {
+  --primary: 213 94% 66%;
+  --primary-foreground: 214 42% 10%;
+  --accent: 48 100% 60%;
+  --accent-foreground: 214 42% 10%;
+  --secondary: 214 24% 22%;
+  --secondary-foreground: 40 20% 94%;
+  --muted: 214 20% 18%;
+  --muted-foreground: 40 14% 79%;
+  --border: 214 20% 30%;
+  --input: 214 20% 30%;
+  --ring: 213 94% 66%;
+}
+
+.vision-tritanopia {
+  --primary: 339 82% 42%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 24 98% 56%;
+  --accent-foreground: 214 40% 10%;
+  --secondary: 18 36% 91%;
+  --secondary-foreground: 214 34% 16%;
+  --muted: 22 22% 88%;
+  --muted-foreground: 215 16% 30%;
+  --border: 12 20% 74%;
+  --input: 12 20% 74%;
+  --ring: 339 82% 42%;
+}
+
+.dark.vision-tritanopia {
+  --primary: 333 90% 68%;
+  --primary-foreground: 214 42% 10%;
+  --accent: 28 100% 62%;
+  --accent-foreground: 214 42% 10%;
+  --secondary: 214 24% 22%;
+  --secondary-foreground: 40 20% 94%;
+  --muted: 214 20% 18%;
+  --muted-foreground: 40 14% 79%;
+  --border: 214 20% 30%;
+  --input: 214 20% 30%;
+  --ring: 333 90% 68%;
+}
+
+.vision-monochromacy {
+  --primary: 0 0% 18%;
+  --primary-foreground: 0 0% 100%;
+  --accent: 0 0% 34%;
+  --accent-foreground: 0 0% 100%;
+  --secondary: 0 0% 88%;
+  --secondary-foreground: 0 0% 14%;
+  --muted: 0 0% 92%;
+  --muted-foreground: 0 0% 28%;
+  --border: 0 0% 74%;
+  --input: 0 0% 74%;
+  --ring: 0 0% 18%;
+}
+
+.dark.vision-monochromacy {
+  --primary: 0 0% 88%;
+  --primary-foreground: 0 0% 10%;
+  --accent: 0 0% 66%;
+  --accent-foreground: 0 0% 10%;
+  --secondary: 0 0% 20%;
+  --secondary-foreground: 0 0% 94%;
+  --muted: 0 0% 16%;
+  --muted-foreground: 0 0% 76%;
+  --border: 0 0% 28%;
+  --input: 0 0% 28%;
+  --ring: 0 0% 88%;
+}
+
 @layer base {
   * {
     @apply border-border;
@@ -81,6 +193,10 @@
 
   a {
     @apply outline-none;
+  }
+
+  select {
+    color-scheme: inherit;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -182,6 +182,8 @@
 
   html {
     scroll-behavior: smooth;
+    scrollbar-color: hsl(var(--primary) / 0.45) hsl(var(--muted) / 0.16);
+    scrollbar-width: thin;
   }
 
   body {
@@ -197,6 +199,29 @@
 
   select {
     color-scheme: inherit;
+  }
+
+  *::-webkit-scrollbar {
+    width: 9px;
+    height: 9px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: hsl(var(--muted) / 0.1);
+  }
+
+  *::-webkit-scrollbar-thumb {
+    border: 2px solid hsl(var(--background));
+    border-radius: 999px;
+    background: hsl(var(--primary) / 0.5);
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--primary) / 0.68);
+  }
+
+  *::-webkit-scrollbar-corner {
+    background: transparent;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily UI/theme changes (CSS variable overrides + a new toggle persisted to `localStorage`) with minimal behavioral impact outside styling and layout.
> 
> **Overview**
> Adds a *color-vision accessibility* mode (default/deuteranopia/protanopia/tritanopia/monochromacy) via a new `VisionToggle`, persisting the selection in `localStorage` and applying it by toggling `vision-*` classes on `documentElement`.
> 
> Introduces per-mode CSS variable palettes for both light/dark themes and updates global scrollbar styling. Minor UI tweaks include widening the responsive breakpoint for the top nav/toggles (`md`→`xl`), making the mobile menu scrollable, updating language/theme toggles to full-width controls, and adding new “current role”/public vs internal project badges driven by new `siteContent.accessibility` copy.
> 
> Also pins the project to Node `24.x` via `package.json` `engines`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0db5326b5c9903f1e72edc6b059eaa3aba778cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->